### PR TITLE
Fixing interface inheritance issues

### DIFF
--- a/SerializeReferenceEditor/Assets/SREditor/Package/package.json
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/package.json
@@ -2,7 +2,7 @@
   "displayName": "Serialize Reference Editor",
   "name": "com.elmortem.serializereferenceeditor",
   "author": "Makar Osokin",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "unity": "2021.3",
   "description": "Custom serialize reference Unity editor",
   "keywords": [


### PR DESCRIPTION
SREditor ignored abstract classes and interfaces if the SR attribute was applied to interfaces.
For code:
```cs
public interface IAction
{
    void DoSomething();
}
public interface IAlternativeAction : IAction
{
		
}
public abstract class BaseAbstractAction : IAction
{
    public int Id;
    public void DoSomething()
    {
        return;
    }
}
[Serializable]
public class RealizationAction : BaseAbstractAction
{
    public string Name;
}
public class SetterActionMonoBehavior : MonoBehaviour
{
	[SR]
	[SerializeReference]
	private IAction _action;
}
```
SetterActionMonoBehavior returned the following result:
![image](https://github.com/user-attachments/assets/e9f291a8-a4fa-4ac8-ac7b-f536ff38d807)
After the correction, everything is returned correctly:
![image](https://github.com/user-attachments/assets/e4514543-c858-4de1-98ce-1903fe34dfc4)
Also replaced `Assembly.GetAssembly(type).GetTypes()` for class types on `AppDomain.CurrentDomain.GetAssemblies().SelectMany(s => s.GetTypes())` because there were difficulties with working with multiple packages.

