### PR TITLE
add generic types support

### DIFF
--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRDrawer.cs
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRDrawer.cs
@@ -31,7 +31,7 @@ namespace SerializeReferenceEditor.Editor
 				return null;
 			}
 
-			string[] typeSplit = property.managedReferenceFieldTypename.Split(char.Parse(" "));
+			string[] typeSplit = property.managedReferenceFieldTypename.Split(new[] { ' ' }, 2);
 			string typeAssembly = typeSplit[0];
 			string typeClass = typeSplit[1];
 			return Type.GetType(typeClass + ", " + typeAssembly);


### PR DESCRIPTION
Now SREditor supports generic types. Previously, the method did not work correctly because it incorrectly split generic type names. Here’s an example of how a generic type looks:
Blacksmith.Gameplay.Cards.IReactionFilterData1[[Blacksmith.Gameplay.Cards.DealDamageAction, Blacksmith, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]`. The type name contains more than one space. Currently, the method splits the type name into two strings based on the first space, which works correctly with regular types but not with generics.