### PR TITLE
Copy/Paste/Cut operations

### DIFF
--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/CopyPropertySRAction.cs
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/CopyPropertySRAction.cs
@@ -1,0 +1,17 @@
+using UnityEditor;
+
+namespace SerializeReferenceEditor.Editor.SRActions
+{
+    public class CopyPropertySRAction : BaseSRAction
+    {
+        public CopyPropertySRAction(SerializedProperty currentProperty, SerializedProperty parentProperty)
+            : base(currentProperty, parentProperty)
+        {
+        }
+
+        protected override void DoApply()
+        {
+            SRClipboard.ManagedReferenceValue = Property.managedReferenceValue;
+        }
+    }
+}

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/CopyPropertySRAction.cs.meta
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/CopyPropertySRAction.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1ede87433ef3403e853336b2c7b26d11
+timeCreated: 1770000000

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/CutPropertySRAction.cs
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/CutPropertySRAction.cs
@@ -1,0 +1,22 @@
+using UnityEditor;
+
+namespace SerializeReferenceEditor.Editor.SRActions
+{
+    public class CutPropertySRAction : BaseSRAction
+    {
+        public CutPropertySRAction(SerializedProperty currentProperty, SerializedProperty parentProperty)
+            : base(currentProperty, parentProperty)
+        {
+        }
+
+        protected override void DoApply()
+        {
+            Undo.RegisterCompleteObjectUndo(Property.serializedObject.targetObject, "Cut element");
+            Undo.FlushUndoRecordObjects();
+
+            SRClipboard.ManagedReferenceValue = Property.managedReferenceValue;
+            Property.managedReferenceValue = null;
+            Property.serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/CutPropertySRAction.cs.meta
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/CutPropertySRAction.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e9b5a5ac9c94408cb095108828def7b0
+timeCreated: 1770000001

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/PastePropertySRAction.cs
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/PastePropertySRAction.cs
@@ -1,0 +1,24 @@
+using UnityEditor;
+
+namespace SerializeReferenceEditor.Editor.SRActions
+{
+    public class PastePropertySRAction : BaseSRAction
+    {
+        public PastePropertySRAction(SerializedProperty currentProperty, SerializedProperty parentProperty)
+            : base(currentProperty, parentProperty)
+        {
+        }
+
+        protected override void DoApply()
+        {
+            if (!SRClipboard.HasValue)
+                return;
+
+            Undo.RegisterCompleteObjectUndo(Property.serializedObject.targetObject, "Paste element");
+            Undo.FlushUndoRecordObjects();
+
+            Property.managedReferenceValue = SRClipboard.ManagedReferenceValue;
+            Property.serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/PastePropertySRAction.cs.meta
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/PastePropertySRAction.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: da1bd126d4434873bef15b20176d8e6e
+timeCreated: 1770000002

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/SRActionFactory.cs
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/SRActionFactory.cs
@@ -23,5 +23,14 @@ namespace SerializeReferenceEditor.Editor.SRActions
 
         public ErasePropertySRAction EraseBuild()
             => new ErasePropertySRAction(_currentProperty, _parentProperty);
+
+        public CopyPropertySRAction CopyBuild()
+            => new CopyPropertySRAction(_currentProperty, _parentProperty);
+
+        public PastePropertySRAction PasteBuild()
+            => new PastePropertySRAction(_currentProperty, _parentProperty);
+
+        public CutPropertySRAction CutBuild()
+            => new CutPropertySRAction(_currentProperty, _parentProperty);
     }
 }

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/SRClipboard.cs
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/SRClipboard.cs
@@ -1,0 +1,9 @@
+namespace SerializeReferenceEditor.Editor.SRActions
+{
+    public static class SRClipboard
+    {
+        public static object ManagedReferenceValue { get; set; }
+
+        public static bool HasValue => ManagedReferenceValue != null;
+    }
+}

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/SRClipboard.cs.meta
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/SRClipboard.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8da5447306724996b06d0b65e16b1d45
+timeCreated: 1770000003

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SearchTree/SRTypesSearchWindowProvider.cs
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SearchTree/SRTypesSearchWindowProvider.cs
@@ -40,6 +40,21 @@ namespace SerializeReferenceEditor.Editor.Drawers
                     userData = srActionFactory.EraseBuild(),
                     level = 1
                 },
+                new(new GUIContent("Copy"))
+                {
+                    userData = srActionFactory.CopyBuild(),
+                    level = 1
+                },
+                new(new GUIContent("Paste"))
+                {
+                    userData = srActionFactory.PasteBuild(),
+                    level = 1
+                },
+                new(new GUIContent("Cut"))
+                {
+                    userData = srActionFactory.CutBuild(),
+                    level = 1
+                },
             };
             list.AddRange(srTypeTreeFactory.MakeTypesTree(srActionFactory));
 

--- a/SerializeReferenceEditor/Assets/SREditor/Package/Scripts/FormerlySerializedTypeAttribute.cs
+++ b/SerializeReferenceEditor/Assets/SREditor/Package/Scripts/FormerlySerializedTypeAttribute.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
+#if UNITY_EDITOR
 using SerializeReferenceEditor.Services;
+#endif
 
 namespace SerializeReferenceEditor
 {


### PR DESCRIPTION
### Motivation
- Provide basic clipboard operations for serialize-reference fields so values (references) can be moved or shared between fields. 
- Ensure copy/paste semantics preserve the original reference (not deep-clone) so mutations affect all pasted locations.

### Description
- Added a simple editor clipboard `SRClipboard` that holds a single `ManagedReferenceValue` and exposes `HasValue` (`SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/SRClipboard.cs`).
- Implemented `Copy`, `Paste`, and `Cut` actions as `CopyPropertySRAction`, `PastePropertySRAction`, and `CutPropertySRAction` respectively, where `Copy` stores the reference, `Paste` assigns the stored reference to the target field, and `Cut` stores the reference then clears the source field (`SerializeReferenceEditor/Assets/SREditor/Package/Editor/Scripts/SRActions/CopyPropertySRAction.cs`, `PastePropertySRAction.cs`, `CutPropertySRAction.cs`).
- Added `Undo` support for destructive/applying operations in `Paste` and `Cut` and applied modified properties after changes.
- Wired the new actions into the action factory and the search window menu so they appear alongside `Erase` (`SRActionFactory.cs` and `SRTypesSearchWindowProvider.cs`).